### PR TITLE
reusing existing sheets

### DIFF
--- a/src/main/groovy/org/gsheets/ExcelFile.groovy
+++ b/src/main/groovy/org/gsheets/ExcelFile.groovy
@@ -37,6 +37,7 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.apache.poi.ss.util.CellRangeAddress
 import org.apache.poi.ss.usermodel.*
 import org.apache.poi.hssf.usermodel.HSSFCell
+import org.apache.poi.hssf.usermodel.HSSFSheet
 
 /**
  * A Groovy builder that wraps Apache POI for generating binary Microsoft Excel sheets.
@@ -126,7 +127,10 @@ class ExcelFile {
         assert name
         assert closure
 
-        sheet = workbook.createSheet(name)
+        sheet = workbook.getSheet(name)
+        if (!sheet) {
+            sheet = workbook.createSheet(name)
+        }
         rowsCounter = 0
 
         closure.delegate = sheet


### PR DESCRIPTION
this allows to define sheet multiple times which is necessary to create references between sheets and fix order

you can only reference sheets already created, so you can not reference the following sheets from the first sheet
